### PR TITLE
get rid of app_recorder. catch all other content-type

### DIFF
--- a/Earthfile
+++ b/Earthfile
@@ -4,7 +4,6 @@ elixir-base:
     FROM elixir:1.12.2-alpine
     WORKDIR /app
     RUN apk add --no-progress --update openssh-client git build-base mysql-client
-    RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan gitlab.annatel.net >> ~/.ssh/known_hosts
     RUN mix local.rebar --force && mix local.hex --force
 
 deps:

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,9 +1,1 @@
 import Config
-
-if(Mix.env() == :test) do
-  config :antl_http_client,
-    logger: :app_recorder
-
-  config :app_recorder,
-    repo: AntlUtilsEcto.TestRepo
-end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule AntlHttpClient.MixProject do
   use Mix.Project
 
-  @version "0.2.0"
+  @version "0.3.0"
 
   def project do
     [
@@ -28,7 +28,7 @@ defmodule AntlHttpClient.MixProject do
     [
       {:finch, "~> 0.16.0"},
       {:bypass, "~> 2.1.0", only: :test},
-      {:app_recorder, "~> 0.4", [env: :prod, hex: "app_recorder", repo: "hexpm"]}
+      {:jason, "~> 1.4"}
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,1 @@
-{:ok, _pid} = AntlUtilsEcto.TestRepo.start_link()
-
 ExUnit.start()


### PR DESCRIPTION
remove dependency to app_recorder + a new little feature.

get rid of app_recorder -> replaced by an anonymous function that is called before and after the request. 
catch all for all other content-types.